### PR TITLE
Station servers preserve state when restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2018-11-14
+
+### Added
+
+- Station servers now save state when killed and restore state when restarted, state handoff works in a clustered environment
+
+### Fixed
+
+- Exception with station `users` array and Poison json encoding is fixed by implementing `UserView`
+
 ## [0.0.2] - 2018-11-13
 
 ### Added
 
-- Ecto migrations are now a release task and run as a pre_start hook in distillery releases.
+- Ecto migrations are now a release task and run as a pre_start hook in distillery releases
 - Station servers are now supervised by Horde and restart on a new node if the running node dies (restarted with new state for now)
 
 ## [0.0.1] - 2018-10-04
 
 ### Added
 
-- Deployments (docker images) now automatically join and leave cluster when running in Production on Kubernetes.
+- Deployments (docker images) now automatically join and leave cluster when running in Production on Kubernetes

--- a/lib/ripple/stations/live_station.ex
+++ b/lib/ripple/stations/live_station.ex
@@ -1,0 +1,14 @@
+defmodule Ripple.Stations.LiveStation do
+  alias Ripple.Tracks.Track
+
+  defstruct id: "",
+            name: "",
+            play_type: "",
+            slug: "",
+            tags: [],
+            creator_id: "",
+            guests: 0,
+            users: [],
+            current_track: %Track{},
+            queue: []
+end

--- a/lib/ripple/stations/station_handoff_store.ex
+++ b/lib/ripple/stations/station_handoff_store.ex
@@ -1,0 +1,30 @@
+defmodule Ripple.Stations.StationHandoffStore do
+  alias :mnesia, as: Mnesia
+  alias Ripple.Stations.LiveStation
+
+  @table __MODULE__
+
+  def init_store do
+    :lbm_kv.create(@table)
+  end
+
+  def put(nil), do: :ok
+
+  def put(%LiveStation{} = station) do
+    :lbm_kv.put(@table, station.slug, station)
+    :ok
+  end
+
+  def get_and_delete(slug) do
+    tx = fn ->
+      [{_, _, station, _}] = Mnesia.read(@table, slug)
+      Mnesia.delete({@table, slug})
+      station
+    end
+
+    case Mnesia.transaction(tx) do
+      {:atomic, station} -> {:ok, station}
+      _ -> {:error, :no_exists}
+    end
+  end
+end

--- a/lib/ripple/stations/station_store_sync.ex
+++ b/lib/ripple/stations/station_store_sync.ex
@@ -1,7 +1,7 @@
 defmodule Ripple.Stations.StationStoreSync do
   use GenServer
 
-  alias Ripple.Stations.{StationStore, StationServer}
+  alias Ripple.Stations.{StationStore, StationHandoffStore, StationServer}
 
   @sync_delay 4_000
 
@@ -23,6 +23,7 @@ defmodule Ripple.Stations.StationStoreSync do
     Process.send_after(self(), :sync_store, @sync_delay)
 
     StationStore.init_store()
+    StationHandoffStore.init_store()
 
     {:ok, state}
   end

--- a/lib/ripple_web/views/station_view.ex
+++ b/lib/ripple_web/views/station_view.ex
@@ -1,6 +1,6 @@
 defmodule RippleWeb.StationView do
   use RippleWeb, :view
-  alias RippleWeb.{StationView, TrackView}
+  alias RippleWeb.{UserView, StationView, TrackView}
 
   def render("index.json", %{stations: stations}) do
     %{stations: render_many(stations, StationView, "station_short.json")}
@@ -19,7 +19,7 @@ defmodule RippleWeb.StationView do
         render_one(Map.get(station, :current_track, nil), TrackView, "current_track.json"),
       queue: Enum.count(Map.get(station, :queue, [])),
       tags: station.tags,
-      users: Enum.count(station.users),
+      users: render_many(Map.get(station, :users, []), UserView, "user.json"),
       guests: Map.get(station, :guests, 0),
       total_listeners: Enum.count(station.users) + Map.get(station, :guests, 0),
       slug: station.slug
@@ -36,7 +36,7 @@ defmodule RippleWeb.StationView do
       current_track:
         render_one(Map.get(station, :current_track, nil), TrackView, "current_track.json"),
       queue: render_many(Map.get(station, :queue, []), TrackView, "track_hidden.json"),
-      users: Map.get(station, :users, []),
+      users: render_many(Map.get(station, :users, []), UserView, "user.json"),
       guests: Map.get(station, :guests, 0)
     }
   end

--- a/lib/ripple_web/views/user_view.ex
+++ b/lib/ripple_web/views/user_view.ex
@@ -1,0 +1,10 @@
+defmodule RippleWeb.UserView do
+  use RippleWeb, :view
+
+  def render("user.json", %{user: user}) do
+    %{
+      id: user.id,
+      username: user.username
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ripple.Mixfile do
   def project do
     [
       app: :ripple,
-      version: "0.0.2",
+      version: "0.0.3",
       elixir: "~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/ripple/stations/station_handoff_store_test.exs
+++ b/test/ripple/stations/station_handoff_store_test.exs
@@ -1,0 +1,87 @@
+defmodule Ripple.StationHandoffStoreTest do
+  use Ripple.DataCase
+
+  alias Ripple.Stations.{StationHandoffStore, LiveStation}
+
+  @valid_attrs %{
+    play_type: "public",
+    tags: []
+  }
+
+  describe "StationHandoffStore" do
+    def station_fixture(username, station_name) do
+      {:ok, user} = Ripple.Users.create_user(%{username: username})
+
+      {:ok, station} =
+        %{}
+        |> Enum.into(@valid_attrs)
+        |> Map.put(:name, station_name)
+        |> Map.put(:creator_id, user.id)
+        |> Ripple.Stations.create_station()
+
+      live_station = %LiveStation{
+        id: station.id,
+        name: station.name,
+        play_type: station.play_type,
+        slug: station.slug,
+        guests: 0,
+        users: [user],
+        current_track: nil,
+        queue: [],
+        creator_id: user.id
+      }
+
+      %{
+        station: live_station,
+        user: user
+      }
+    end
+
+    setup do
+      :mnesia.clear_table(StationHandoffStore)
+      station_fixture("tester", "Test Station")
+    end
+
+    test "Ensure station handoff store started" do
+      assert StationHandoffStore in :mnesia.system_info(:tables)
+    end
+
+    test "put/1 successfully inserts new station", %{station: station} do
+      assert :ok == StationHandoffStore.put(station)
+      [{_, _, saved_station, _}] = :mnesia.dirty_read(StationHandoffStore, station.slug)
+      assert saved_station == station
+    end
+
+    test "put/1 succesfully replaces station with same slug", %{station: station} do
+      assert :ok == StationHandoffStore.put(station)
+      new_station = Map.put(station, :guests, 1)
+      assert :ok == StationHandoffStore.put(new_station)
+      [{_, _, saved_station, _}] = :mnesia.dirty_read(StationHandoffStore, station.slug)
+      assert saved_station == new_station
+    end
+
+    test "put/1 errors when argument not a station" do
+      assert_raise FunctionClauseError,
+                   "no function clause matching in Ripple.Stations.StationHandoffStore.put/1",
+                   fn ->
+                     StationHandoffStore.put(%{this_is: "not a station"})
+                   end
+    end
+
+    test "put/1 does nothing when attempting to put nil" do
+      assert :ok == StationHandoffStore.put(nil)
+      assert :mnesia.table_info(StationHandoffStore, :size) == 0
+    end
+
+    test "get_and_delete/1 succesfully returns and deletes a station", %{station: station} do
+      assert :ok == StationHandoffStore.put(station)
+      assert {:ok, saved_station} = StationHandoffStore.get_and_delete(station.slug)
+      assert saved_station == station
+      assert :mnesia.table_info(StationHandoffStore, :size) == 0
+    end
+
+    test "get_and_delete/1 errors when station with slug not in store" do
+      assert {:error, :no_exists} == StationHandoffStore.get_and_delete("no-exists")
+    end
+  end
+end

--- a/test/ripple/stations/station_server_test.exs
+++ b/test/ripple/stations/station_server_test.exs
@@ -1,31 +1,82 @@
 defmodule Ripple.StationServerTest do
   use Ripple.DataCase
 
-  alias Ripple.Stations.StationServer
+  alias Ripple.Stations.{StationServer, LiveStation, StationStore, StationHandoffStore}
 
-  describe "station server" do
-    @base_state %{
-      name: "some name",
-      slug: "some-slug",
-      tags: [],
-      guests: 0,
-      queue: [],
-      current_track: nil
-    }
-
+  describe "StationServer" do
     @track_url "https://www.youtube.com/watch?v=4Rc-NGWEHdU"
 
     setup do
       {:ok, user} = Ripple.Users.create_user(%{username: "tester"})
-      %{state: Map.put(@base_state, :users, [user]), user: user}
+
+      {:ok, station} =
+        Ripple.Stations.create_station(%{
+          creator_id: user.id,
+          tags: [],
+          play_type: "public",
+          name: "Test Station"
+        })
+
+      state = %LiveStation{
+        id: station.id,
+        name: station.name,
+        play_type: station.play_type,
+        slug: station.slug,
+        guests: 0,
+        users: [user],
+        current_track: nil,
+        queue: [],
+        creator_id: user.id
+      }
+
+      %{state: state, user: user, station: station}
     end
 
-    test "add a user to a station", %{state: state, user: user} do
+    test "init successfully creates station server for a user", %{
+      state: state,
+      station: station,
+      user: user
+    } do
+      assert {:ok, result_station} = StationServer.init({station, user})
+      assert result_station == state
+    end
+
+    test "init succesfully creates station server for a guest", %{state: state, station: station} do
+      assert {:ok, result_station} = StationServer.init({station, nil})
+      assert result_station == %LiveStation{state | users: [], guests: 1}
+    end
+
+    test "init successfully retrieves station from handoff store", %{
+      state: state,
+      station: station,
+      user: user
+    } do
+      initial_state = %LiveStation{state | tags: ["test"]}
+      assert :ok == StationHandoffStore.put(initial_state)
+      assert {:ok, result_station} = StationServer.init({station, user})
+      assert result_station == %LiveStation{initial_state | users: []}
+    end
+
+    test "init successfully saves state to handoff store when exitting", %{state: state} do
+      assert :mnesia.table_info(StationHandoffStore, :size) == 0
+      assert :ok = StationServer.terminate(:exit, state)
+      assert [{_, _, saved_state, _}] = :mnesia.dirty_read(StationHandoffStore, state.slug)
+      assert saved_state == state
+    end
+
+    test "add a new user to a station", %{state: state, user: user} do
       {:ok, new_user} = Ripple.Users.create_user(%{username: "tester2"})
       {:reply, :ok, new_state} = StationServer.handle_call({:add_user, new_user}, self(), state)
-      assert state.users == [user]
-      assert new_state.users == [user, new_user]
-      assert Map.delete(new_state, :users) == Map.delete(state, :users)
+      assert new_state == %LiveStation{state | users: [user, new_user]}
+    end
+
+    test "adding a duplicate user to a station does nothing", %{state: state, user: user} do
+      initial_state = Map.put(state, :users, [user])
+
+      assert {:reply, :ok, returned_state} =
+               StationServer.handle_call({:add_user, user}, self(), initial_state)
+
+      assert returned_state == initial_state
     end
 
     test "add a guest to a station", %{state: state} do
@@ -42,23 +93,91 @@ defmodule Ripple.StationServerTest do
       assert Map.delete(new_state, :users) == Map.delete(state, :users)
     end
 
-    test "remove a guest from a station with 1 guest", %{state: state, user: user} do
-      {:reply, :ok, state_with_guest} = StationServer.handle_call({:add_user, nil}, self(), state)
-      assert state_with_guest.users == [user]
-      assert state_with_guest.guests == 1
+    test "remove a guest from a station with 1 guest", %{state: state} do
+      initial_state = %LiveStation{state | users: [], guests: 1}
 
-      {:reply, false, state_with_guest_without_user} =
-        StationServer.handle_call({:remove_user, user}, self(), state_with_guest)
+      assert {:reply, true, new_state} =
+               StationServer.handle_call({:remove_user, nil}, self(), initial_state)
 
-      assert state_with_guest_without_user.users == []
-      assert state_with_guest_without_user.guests == 1
+      assert new_state == %LiveStation{initial_state | guests: 0}
+    end
 
-      {:reply, true, new_state} =
-        StationServer.handle_call({:remove_user, nil}, self(), state_with_guest_without_user)
+    test "remove the last user from a station with guests", %{state: state, user: user} do
+      initial_state = %LiveStation{state | guests: 2}
 
-      assert new_state.users == []
-      assert new_state.guests == 0
-      assert Map.delete(new_state, :users) == Map.delete(state, :users)
+      assert {:reply, false, new_state} =
+               StationServer.handle_call({:remove_user, user}, self(), initial_state)
+
+      assert new_state == %LiveStation{initial_state | users: []}
+    end
+
+    test "remove the last guest from a station with users", %{state: state} do
+      initial_state = %LiveStation{state | guests: 1}
+
+      assert {:reply, false, new_state} =
+               StationServer.handle_call({:remove_user, nil}, self(), initial_state)
+
+      assert new_state == %LiveStation{initial_state | guests: 0}
+    end
+
+    test "state not saved to handoff when exit called by server", %{state: state, user: user} do
+      assert {:reply, true, new_state} =
+               StationServer.handle_call({:remove_user, user}, self(), state)
+
+      assert :mnesia.table_info(StationHandoffStore, :size) == 0
+    end
+
+    test "station removed from station store when exit called by server", %{
+      state: state,
+      user: user
+    } do
+      assert {:reply, true, new_state} =
+               StationServer.handle_call({:remove_user, user}, self(), state)
+
+      assert StationStore.read(state.slug) == {:ok, nil}
+    end
+
+    test "station with private play_type does not allow random user to play tracks", %{
+      state: state,
+      user: user
+    } do
+      {:ok, new_user} = Ripple.Users.create_user(%{username: "tester2"})
+      initial_state = %LiveStation{state | play_type: "private", users: [user, new_user]}
+
+      assert {:reply, {:error, :not_creator}, returned_state} =
+               StationServer.handle_cast({:add_track, @track_url, new_user}, initial_state)
+
+      assert returned_state == initial_state
+    end
+
+    test "station with private play_type allows creator to play tracks", %{
+      state: state,
+      user: user
+    } do
+      initial_state = %LiveStation{state | play_type: "private"}
+
+      assert {:noreply, returned_state} =
+               StationServer.handle_cast({:add_track, @track_url, user}, initial_state)
+
+      assert returned_state.current_track.url == @track_url
+      assert %LiveStation{returned_state | current_track: nil} == initial_state
+    end
+
+    test "adding a track fails if user not in station", %{state: state, user: user} do
+      initial_state = %LiveStation{state | users: []}
+
+      assert {:reply, {:error, :not_in_station}, new_state} =
+               StationServer.handle_cast({:add_track, @track_url, user}, initial_state)
+
+      assert new_state == initial_state
+    end
+
+    test "adding a track fails if guest is passed in", %{state: state} do
+      assert_raise FunctionClauseError,
+                   "no function clause matching in Ripple.Stations.StationServer.handle_cast/2",
+                   fn ->
+                     StationServer.handle_cast({:add_track, @track_url, nil}, state)
+                   end
     end
 
     test "add a track to a station with no track", %{state: state, user: user} do

--- a/test/ripple/stations/station_store_test.exs
+++ b/test/ripple/stations/station_store_test.exs
@@ -8,7 +8,7 @@ defmodule Ripple.StationStoreTest do
     tags: []
   }
 
-  describe "station store" do
+  describe "StationStore" do
     def station_fixture(username, station_name) do
       {:ok, user} = Ripple.Users.create_user(%{username: username})
 
@@ -43,9 +43,8 @@ defmodule Ripple.StationStoreTest do
       station_fixture("tester", "Test Station")
     end
 
-    test "Ensure store started" do
-      tables = :mnesia.system_info(:tables)
-      assert StationStore in tables == true
+    test "Ensure station store started" do
+      assert StationStore in :mnesia.system_info(:tables)
     end
 
     test "list_stations/0 returns empty list when no stations are live", %{

--- a/test/support/cluster_helper.ex
+++ b/test/support/cluster_helper.ex
@@ -29,6 +29,7 @@ defmodule Ripple.ClusterHelper do
   def cleanup() do
     Ripple.Repo.delete_all(Ripple.Stations.Station)
     Ripple.Repo.delete_all(Ripple.Users.User)
+    Ripple.Repo.delete_all(Ripple.Tracks.Track)
 
     stations = Horde.Supervisor.which_children(Ripple.StationSupervisor)
 
@@ -36,6 +37,9 @@ defmodule Ripple.ClusterHelper do
     |> Enum.map(&List.first/1)
     |> Enum.map(&elem(&1, 0))
     |> Enum.each(&Horde.Supervisor.terminate_child(Ripple.StationSupervisor, &1))
+
+    :mnesia.clear_table(Ripple.Stations.StationStore)
+    :mnesia.clear_table(Ripple.Stations.StationHandoffStore)
   end
 
   def heal(cluster) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,9 +6,9 @@
 Node.start(:"primary@127.0.0.1", :longnames)
 :mnesia.start()
 Ripple.Stations.StationStore.init_store()
+Ripple.Stations.StationHandoffStore.init_store()
 
 Application.ensure_all_started(:ex_unit_clustered_case)
 
 ExUnit.start()
-# Ecto.Adapters.SQL.Sandbox.mode(Ripple.Repo, :manual)
 Ecto.Adapters.SQL.Sandbox.mode(Ripple.Repo, {:shared, self()})


### PR DESCRIPTION
When station servers crash or are killed they preserver their state to the handoff in `terminate/2` and restore it when restarted.

# Changelog:

## [0.0.3] - 2018-11-14

### Added

- Station servers now save state when killed and restore state when restarted, state handoff works in a clustered environment

### Fixed

- Exception with station `users` array and Poison json encoding is fixed by implementing `UserView`