### PR TITLE
Chat messages are now processed into message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2018-11-14
+
+### Added
+
+- Chat messages are now processed and sent back as an array of message types. For example, the message `@daniel check out this link: https://ripple.fm` will be processed as:
+  ```
+  [
+    %{ type: "mention", value: "@daniel" },
+    %{ type: "text", value: "check out this link:" },
+    %{ type: "link", value: "https://ripple.fm" }
+  ]
+  ```
+
 ## [0.0.3] - 2018-11-14
 
 ### Added

--- a/lib/ripple_web/channels/station_channel.ex
+++ b/lib/ripple_web/channels/station_channel.ex
@@ -3,6 +3,7 @@ defmodule RippleWeb.StationChannel do
 
   alias Ripple.Stations
   alias Ripple.Stations.{StationStore, StationServer}
+  alias RippleWeb.Helpers.ChatHelper
 
   def join("stations:" <> slug, _payload, socket) do
     case StationStore.read(slug) do
@@ -36,13 +37,17 @@ defmodule RippleWeb.StationChannel do
 
   def handle_in("chat", %{"text" => text}, socket) do
     unless socket.assigns.current_user == nil do
-      broadcast(socket, "station_chat", %{sender: socket.assigns.current_user, text: text})
+      broadcast(socket, "station_chat", %{
+        sender: socket.assigns.current_user,
+        message: ChatHelper.process(text)
+      })
     end
 
     {:noreply, socket}
   end
 
   defp get_slug(socket) do
-    socket.topic |> String.slice(String.length("stations:"), String.length(socket.topic))
+    ["stations", slug] = String.split(socket.topic, ":")
+    slug
   end
 end

--- a/lib/ripple_web/helpers/chat_helper.ex
+++ b/lib/ripple_web/helpers/chat_helper.ex
@@ -1,0 +1,29 @@
+defmodule RippleWeb.Helpers.ChatHelper do
+  def process(text) when is_binary(text) do
+    text |> String.split(" ") |> Enum.map(&parse/1) |> Enum.reduce([], &merge_types/2)
+  end
+
+  defp merge_types(current, []), do: [current]
+
+  defp merge_types(%{type: "text", value: value} = current, list) do
+    {last, new_list} = List.pop_at(list, Enum.count(list) - 1)
+
+    new_last =
+      case last do
+        %{type: "text", value: last_val} -> [%{type: "text", value: "#{last_val} #{value}"}]
+        _ -> [last, current]
+      end
+
+    new_list ++ new_last
+  end
+
+  defp merge_types(current, list), do: list ++ [current]
+
+  defp parse("http" <> _link = url), do: %{type: "link", value: url}
+
+  defp parse("www." <> _link = url), do: %{type: "link", value: url}
+
+  defp parse("@" <> _username = mention), do: %{type: "mention", value: mention}
+
+  defp parse(text), do: %{type: "text", value: text}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ripple.Mixfile do
   def project do
     [
       app: :ripple,
-      version: "0.0.3",
+      version: "0.1.0",
       elixir: "~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/ripple_web/helpers/chat_helper_test.exs
+++ b/test/ripple_web/helpers/chat_helper_test.exs
@@ -1,0 +1,63 @@
+defmodule RippleWeb.ChatHelperTest do
+  use Ripple.DataCase
+
+  alias RippleWeb.Helpers.ChatHelper
+
+  describe "ChatHelper" do
+    test "process/1 successfully processes only text" do
+      text = "This is a test"
+      assert [%{type: "text", value: text}] == ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes only a url starting with https" do
+      text = "https://ripple.fm"
+      assert [%{type: "link", value: text}] == ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes only a url starting with www" do
+      text = "www.ripple.fm"
+      assert [%{type: "link", value: text}] == ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes multiple urls" do
+      text = "https://ripple.fm www.ripple.fm"
+
+      assert [
+               %{type: "link", value: "https://ripple.fm"},
+               %{type: "link", value: "www.ripple.fm"}
+             ] == ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes only a mention" do
+      text = "@tester"
+      assert [%{type: "mention", value: text}] == ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes multiple mentions" do
+      text = "@tester @admin"
+
+      assert [%{type: "mention", value: "@tester"}, %{type: "mention", value: "@admin"}] ==
+               ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes a message with text, url, and a mention" do
+      text = "look at this link https://ripple.fm @tester"
+
+      assert [
+               %{type: "text", value: "look at this link"},
+               %{type: "link", value: "https://ripple.fm"},
+               %{type: "mention", value: "@tester"}
+             ] == ChatHelper.process(text)
+    end
+
+    test "process/1 successfully processes a message with text, link, and text" do
+      text = "look at https://ripple.fm test 123"
+
+      assert [
+               %{type: "text", value: "look at"},
+               %{type: "link", value: "https://ripple.fm"},
+               %{type: "text", value: "test 123"}
+             ] == ChatHelper.process(text)
+    end
+  end
+end


### PR DESCRIPTION
# Changelog

## [0.1.0] - 2018-11-14

### Added

- Chat messages are now processed and sent back as an array of message types. For example, the message `@daniel check out this link: https://ripple.fm` will be processed as:
  ```
  [
    %{ type: "mention", value: "@daniel" },
    %{ type: "text", value: "check out this link:" },
    %{ type: "link", value: "https://ripple.fm" }
  ]
  ```
