### PR TITLE
Fix Poison json errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2018-11-23
+
+### Fixed
+
+- Websockets are now accepted from all origins
+- Poison no longer throws exceptions when decoding tracks and users
+
 ## [0.1.2] - 2018-11-19
 
 ### Fixed

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,6 +16,7 @@ use Mix.Config
 config :ripple, RippleWeb.Endpoint,
   load_from_system_env: true,
   url: [host: "api.ripple.fm", port: 80],
+  check_origin: false,
   server: true
 
 # Do not print debug messages in production

--- a/lib/ripple/tracks/track.ex
+++ b/lib/ripple/tracks/track.ex
@@ -3,6 +3,7 @@ defmodule Ripple.Tracks.Track do
   import Ecto.Changeset
   alias Ripple.Tracks.Track
 
+  @derive {Poison.Encoder, except: []}
   schema "tracks" do
     field(:artwork_url, :string, default: nil)
     field(:duration, :integer)

--- a/lib/ripple/users/user.ex
+++ b/lib/ripple/users/user.ex
@@ -5,6 +5,7 @@ defmodule Ripple.Users.User do
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
+  @derive {Poison.Encoder, only: [:id, :username]}
   schema "users" do
     field(:username, :string)
   end

--- a/lib/ripple_web/views/track_view.ex
+++ b/lib/ripple_web/views/track_view.ex
@@ -1,6 +1,8 @@
 defmodule RippleWeb.TrackView do
   use RippleWeb, :view
 
+  alias RippleWeb.UserView
+
   def render("track.json", %{track: track}) do
     %{
       artwork_url: track.artwork_url,
@@ -19,7 +21,7 @@ defmodule RippleWeb.TrackView do
       artwork_url: track.artwork_url,
       duration: track.duration,
       timestamp: track.timestamp,
-      dj: track.dj,
+      dj: render_one(track.dj, UserView, "user.json"),
       url: track.url,
       poster: track.poster,
       name: track.name,
@@ -30,8 +32,10 @@ defmodule RippleWeb.TrackView do
 
   def render("track_hidden.json", %{track: track}) do
     %{
-      username: track.dj.username,
-      id: track.dj.id
+      dj: %{
+        username: track.dj.username,
+        id: track.dj.id
+      }
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ripple.Mixfile do
   def project do
     [
       app: :ripple,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
## [0.1.3] - 2018-11-23

### Fixed

- Websockets are now accepted from all origins
- Poison no longer throws exceptions when decoding tracks and users