### PR TITLE
Rename Station field `play_type` to `visibility`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2018-11-23
+
+### Changed
+
+- Station field `play_type` renamed to `visibility`
+
 ## [0.1.3] - 2018-11-23
 
 ### Fixed

--- a/lib/ripple/stations/live_station.ex
+++ b/lib/ripple/stations/live_station.ex
@@ -3,7 +3,7 @@ defmodule Ripple.Stations.LiveStation do
 
   defstruct id: "",
             name: "",
-            play_type: "",
+            visibility: "",
             slug: "",
             tags: [],
             creator_id: "",

--- a/lib/ripple/stations/station.ex
+++ b/lib/ripple/stations/station.ex
@@ -7,7 +7,7 @@ defmodule Ripple.Stations.Station do
   @foreign_key_type :binary_id
   schema "stations" do
     field(:name, :string)
-    field(:play_type, :string)
+    field(:visibility, :string)
     field(:slug, :string)
     field(:tags, {:array, :string})
     field(:creator_id, :binary_id)
@@ -18,17 +18,17 @@ defmodule Ripple.Stations.Station do
   @doc false
   def changeset(%Station{} = station, attrs) do
     station
-    |> cast(attrs, [:name, :play_type, :tags, :creator_id])
-    |> validate_required([:name, :play_type, :tags, :creator_id])
+    |> cast(attrs, [:name, :visibility, :tags, :creator_id])
+    |> validate_required([:name, :visibility, :tags, :creator_id])
     |> validate_length(:name, min: 4)
-    |> validate_inclusion(:play_type, ["public", "private"])
+    |> validate_inclusion(:visibility, ["public", "private"])
     |> generate_slug
     |> validate_required([:slug])
     |> unique_constraint(:slug)
   end
 
   defp generate_slug(changeset) do
-    case get_field(changeset, :play_type) do
+    case get_field(changeset, :visibility) do
       "private" -> put_change(changeset, :slug, Ecto.UUID.generate() |> binary_part(24, 8))
       "public" -> put_change(changeset, :slug, Slug.slugify(get_field(changeset, :name)))
       _ -> changeset

--- a/lib/ripple/stations/station_server.ex
+++ b/lib/ripple/stations/station_server.ex
@@ -101,7 +101,7 @@ defmodule Ripple.Stations.StationServer do
 
   def handle_cast(
         {:add_track, track_url, %User{} = user},
-        %LiveStation{play_type: "private", current_track: nil} = state
+        %LiveStation{visibility: "private", current_track: nil} = state
       ) do
     if user.id == state.creator_id do
       track = Tracks.get_or_create_track(track_url) |> Map.put(:dj, user)
@@ -113,7 +113,7 @@ defmodule Ripple.Stations.StationServer do
 
   def handle_cast(
         {:add_track, track_url, %User{} = user},
-        %LiveStation{play_type: "private"} = state
+        %LiveStation{visibility: "private"} = state
       ) do
     if user.id == state.creator_id do
       track = Tracks.get_or_create_track(track_url) |> Map.put(:dj, user)
@@ -190,7 +190,7 @@ defmodule Ripple.Stations.StationServer do
     %LiveStation{
       id: station.id,
       name: station.name,
-      play_type: station.play_type,
+      visibility: station.visibility,
       slug: station.slug,
       creator_id: creator_id,
       guests: 1,
@@ -207,7 +207,7 @@ defmodule Ripple.Stations.StationServer do
     %LiveStation{
       id: station.id,
       name: station.name,
-      play_type: station.play_type,
+      visibility: station.visibility,
       slug: station.slug,
       creator_id: creator_id,
       guests: 0,

--- a/lib/ripple/stations/station_store.ex
+++ b/lib/ripple/stations/station_store.ex
@@ -73,7 +73,7 @@ defmodule Ripple.Stations.StationStore do
   end
 
   def list_stations(start \\ 0, e \\ 10) do
-    {:ok, res} = :lbm_kv.match(@table, :_, %{play_type: "public"})
+    {:ok, res} = :lbm_kv.match(@table, :_, %{visibility: "public"})
 
     stations = res |> Stream.map(&elem(&1, 1)) |> Enum.reverse() |> Enum.slice(start, e)
 

--- a/lib/ripple_web/views/station_view.ex
+++ b/lib/ripple_web/views/station_view.ex
@@ -14,7 +14,7 @@ defmodule RippleWeb.StationView do
     %{
       id: station.id,
       name: station.name,
-      play_type: station.play_type,
+      visibility: station.visibility,
       current_track:
         render_one(Map.get(station, :current_track, nil), TrackView, "current_track.json"),
       queue: Enum.count(Map.get(station, :queue, [])),
@@ -31,7 +31,7 @@ defmodule RippleWeb.StationView do
       id: station.id,
       name: station.name,
       slug: station.slug,
-      play_type: station.play_type,
+      visibility: station.visibility,
       tags: station.tags,
       current_track:
         render_one(Map.get(station, :current_track, nil), TrackView, "current_track.json"),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ripple.Mixfile do
   def project do
     [
       app: :ripple,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/priv/repo/migrations/20180204103410_create_stations.exs
+++ b/priv/repo/migrations/20180204103410_create_stations.exs
@@ -5,7 +5,7 @@ defmodule Ripple.Repo.Migrations.CreateStations do
     create table(:stations, primary_key: false) do
       add(:id, :binary_id, primary_key: true)
       add(:name, :string)
-      add(:play_type, :string)
+      add(:visibility, :string)
       add(:slug, :string)
       add(:tags, {:array, :string})
       add(:creator_id, references(:users, on_delete: :nothing, type: :binary_id))

--- a/test/ripple/cluster/station_store_sync_test.exs
+++ b/test/ripple/cluster/station_store_sync_test.exs
@@ -68,7 +68,7 @@ defmodule Ripple.StationStoreSyncTest do
 
       {:ok, station} =
         Cluster.call(node, Ripple.Stations, :create_station, [
-          %{creator_id: user.id, name: "Test Station", play_type: "public", tags: []}
+          %{creator_id: user.id, name: "Test Station", visibility: "public", tags: []}
         ])
 
       {:ok, _pid} = Cluster.call(node, Ripple.Stations.StationServer, :start, [station, user])

--- a/test/ripple/cluster/station_supervisor_test.exs
+++ b/test/ripple/cluster/station_supervisor_test.exs
@@ -49,7 +49,7 @@ defmodule Ripple.StationSupervisorTest do
 
       {:ok, station} =
         Cluster.call(node, Ripple.Stations, :create_station, [
-          %{creator_id: user.id, name: "Test Station", play_type: "public", tags: []}
+          %{creator_id: user.id, name: "Test Station", visibility: "public", tags: []}
         ])
 
       {:ok, pid} = Cluster.call(node, StationServer, :start, [station, user])
@@ -74,7 +74,7 @@ defmodule Ripple.StationSupervisorTest do
 
       {:ok, station} =
         Cluster.call(node, Ripple.Stations, :create_station, [
-          %{creator_id: user.id, name: "Test Station", play_type: "public", tags: []}
+          %{creator_id: user.id, name: "Test Station", visibility: "public", tags: []}
         ])
 
       Cluster.call(node, StationServer, :start, [station, user])
@@ -103,7 +103,7 @@ defmodule Ripple.StationSupervisorTest do
 
       {:ok, station} =
         Cluster.call(node, Ripple.Stations, :create_station, [
-          %{creator_id: user.id, name: "Test Station", play_type: "public", tags: []}
+          %{creator_id: user.id, name: "Test Station", visibility: "public", tags: []}
         ])
 
       {:ok, first_pid} = Cluster.call(node, StationServer, :start, [station, user])
@@ -129,7 +129,7 @@ defmodule Ripple.StationSupervisorTest do
 
       {:ok, station} =
         Cluster.call(node, Ripple.Stations, :create_station, [
-          %{creator_id: user.id, name: "Test Station", play_type: "public", tags: []}
+          %{creator_id: user.id, name: "Test Station", visibility: "public", tags: []}
         ])
 
       {:ok, first_pid} = Cluster.call(node, StationServer, :start, [station, user])

--- a/test/ripple/stations/station_handoff_store_test.exs
+++ b/test/ripple/stations/station_handoff_store_test.exs
@@ -4,7 +4,7 @@ defmodule Ripple.StationHandoffStoreTest do
   alias Ripple.Stations.{StationHandoffStore, LiveStation}
 
   @valid_attrs %{
-    play_type: "public",
+    visibility: "public",
     tags: []
   }
 
@@ -22,7 +22,7 @@ defmodule Ripple.StationHandoffStoreTest do
       live_station = %LiveStation{
         id: station.id,
         name: station.name,
-        play_type: station.play_type,
+        visibility: station.visibility,
         slug: station.slug,
         guests: 0,
         users: [user],

--- a/test/ripple/stations/station_server_test.exs
+++ b/test/ripple/stations/station_server_test.exs
@@ -13,14 +13,14 @@ defmodule Ripple.StationServerTest do
         Ripple.Stations.create_station(%{
           creator_id: user.id,
           tags: [],
-          play_type: "public",
+          visibility: "public",
           name: "Test Station"
         })
 
       state = %LiveStation{
         id: station.id,
         name: station.name,
-        play_type: station.play_type,
+        visibility: station.visibility,
         slug: station.slug,
         guests: 0,
         users: [user],
@@ -135,32 +135,6 @@ defmodule Ripple.StationServerTest do
                StationServer.handle_call({:remove_user, user}, self(), state)
 
       assert StationStore.read(state.slug) == {:ok, nil}
-    end
-
-    test "station with private play_type does not allow random user to play tracks", %{
-      state: state,
-      user: user
-    } do
-      {:ok, new_user} = Ripple.Users.create_user(%{username: "tester2"})
-      initial_state = %LiveStation{state | play_type: "private", users: [user, new_user]}
-
-      assert {:reply, {:error, :not_creator}, returned_state} =
-               StationServer.handle_cast({:add_track, @track_url, new_user}, initial_state)
-
-      assert returned_state == initial_state
-    end
-
-    test "station with private play_type allows creator to play tracks", %{
-      state: state,
-      user: user
-    } do
-      initial_state = %LiveStation{state | play_type: "private"}
-
-      assert {:noreply, returned_state} =
-               StationServer.handle_cast({:add_track, @track_url, user}, initial_state)
-
-      assert returned_state.current_track.url == @track_url
-      assert %LiveStation{returned_state | current_track: nil} == initial_state
     end
 
     test "adding a track fails if user not in station", %{state: state, user: user} do

--- a/test/ripple/stations/stations_test.exs
+++ b/test/ripple/stations/stations_test.exs
@@ -8,11 +8,11 @@ defmodule Ripple.StationsTest do
 
     @valid_attrs %{
       name: "some name",
-      play_type: "public",
+      visibility: "public",
       tags: []
     }
-    @valid_attrs_with_slug %{name: "with slug", slug: "test-room", play_type: "public", tags: []}
-    @invalid_attrs %{name: nil, play_type: nil, tags: nil}
+    @valid_attrs_with_slug %{name: "with slug", slug: "test-room", visibility: "public", tags: []}
+    @invalid_attrs %{name: nil, visibility: nil, tags: nil}
 
     def station_fixture(attrs \\ %{}) do
       {:ok, user} = Ripple.Users.create_user(%{username: "tester"})
@@ -43,7 +43,7 @@ defmodule Ripple.StationsTest do
                Stations.create_station(@valid_attrs |> Map.put(:creator_id, user.id))
 
       assert station.name == "some name"
-      assert station.play_type == "public"
+      assert station.visibility == "public"
       assert station.slug == "some-name"
       assert station.tags == []
     end

--- a/test/ripple_web/controllers/station_controller_test.exs
+++ b/test/ripple_web/controllers/station_controller_test.exs
@@ -3,8 +3,8 @@ defmodule RippleWeb.StationControllerTest do
 
   alias Ripple.Stations
 
-  @create_attrs %{name: "some name", play_type: "public", tags: []}
-  @invalid_attrs %{name: nil, play_type: nil, tags: nil}
+  @create_attrs %{name: "some name", visibility: "public", tags: []}
+  @invalid_attrs %{name: nil, visibility: nil, tags: nil}
 
   def fixture(:station) do
     {:ok, user} = Ripple.Users.create_user(%{username: "tester"})
@@ -64,7 +64,7 @@ defmodule RippleWeb.StationControllerTest do
                "slug" => slug,
                "id" => id,
                "name" => "some name",
-               "play_type" => "public",
+               "visibility" => "public",
                "tags" => [],
                "current_track" => nil,
                "guests" => 0,


### PR DESCRIPTION
## [0.1.4] - 2018-11-23

### Changed

- Station field `play_type` renamed to `visibility`