### PR TITLE
Stations now have track history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2018-12-21
+
+### Added
+
+- Stations now save track history and current track in postgres
+- `/stations/:slug/history` endpoint for fetching station track history
+
 ## [0.1.4] - 2018-11-23
 
 ### Changed

--- a/lib/ripple/application.ex
+++ b/lib/ripple/application.ex
@@ -13,6 +13,7 @@ defmodule Ripple.Application do
       supervisor(RippleWeb.Endpoint, []),
       # Start station echo
       worker(RippleWeb.Broadcasters.StationBroadcaster, [], restart: :permanent),
+      worker(Ripple.Stations.StationEventListener, [], restart: :permanent),
       # Start your own worker by calling: Ripple.Worker.start_link(arg1, arg2, arg3)
       # worker(Ripple.Worker, [arg1, arg2, arg3]),
       {Horde.Registry, name: Ripple.StationRegistry},

--- a/lib/ripple/stations/station_event_listener.ex
+++ b/lib/ripple/stations/station_event_listener.ex
@@ -1,0 +1,49 @@
+defmodule Ripple.Stations.StationEventListener do
+  use GenServer
+  import Ecto.Query
+
+  alias Ripple.Tracks.Track
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ok, name: :station_event_listener)
+  end
+
+  def init(_) do
+    EventBus.subscribe(
+      {__MODULE__, ["station_track_started", "station_track_finished", "station_stopped"]}
+    )
+
+    {:ok, :ok}
+  end
+
+  def process({topic, id} = e) do
+    try do
+      event = EventBus.fetch_event(e)
+      process(topic, event.data)
+      EventBus.mark_as_completed({__MODULE__, topic, id})
+    rescue
+      _ -> nil
+    catch
+      :exit, _ -> nil
+      _ -> nil
+    end
+  end
+
+  def process(:station_track_started, %{station: station, target: %Track{} = track}) do
+    Ripple.Stations.add_track_to_history(station.id, track.dj.id, track.id)
+  end
+
+  def process(:station_track_finished, %{station: station}) do
+    Ripple.Stations.mark_track_as_finished(station.id)
+  end
+
+  def process(:station_stopped, %{station: station}) do
+    Ripple.Repo.transaction(fn ->
+      from(t in Ripple.Stations.StationTrackHistory,
+        where: t.station_id == ^station.id,
+        where: is_nil(t.finished_at)
+      )
+      |> Ripple.Repo.update_all(set: [finished_at: DateTime.utc_now()])
+    end)
+  end
+end

--- a/lib/ripple/stations/station_server.ex
+++ b/lib/ripple/stations/station_server.ex
@@ -151,13 +151,13 @@ defmodule Ripple.Stations.StationServer do
 
   def handle_info(:track_finished, %LiveStation{queue: []} = state) do
     new_state = %LiveStation{state | current_track: nil}
-    emit_event(:station_track_finished, %{station: new_state, target: new_state})
+    emit_event(:station_track_finished, %{station: new_state, target: state.current_track})
     {:noreply, new_state}
   end
 
   def handle_info(:track_finished, %LiveStation{queue: [next | queue]} = state) do
     new_state = %LiveStation{state | current_track: next, queue: queue}
-    emit_event(:station_track_finished, %{station: new_state, target: new_state})
+    emit_event(:station_track_finished, %{station: new_state, target: state.current_track})
     new_state |> start_track
   end
 

--- a/lib/ripple/stations/station_track_history.ex
+++ b/lib/ripple/stations/station_track_history.ex
@@ -1,0 +1,54 @@
+defmodule Ripple.Stations.StationTrackHistory do
+  use Ecto.Schema
+  import Ecto.Query
+  import Ecto.Changeset
+
+  alias Ripple.Stations.StationTrackHistory
+  alias Ripple.Tracks.Track
+  alias Ripple.Users.User
+
+  @primary_key false
+  schema "station_track_history" do
+    field(:station_id, :binary_id)
+    field(:user_id, :binary_id)
+    field(:track_id, :integer)
+    timestamps(inserted_at: :started_at, updated_at: false)
+    field(:finished_at, :naive_datetime, default: nil)
+  end
+
+  def changeset(%StationTrackHistory{} = history, attrs) do
+    history
+    |> cast(attrs, [:station_id, :user_id, :track_id])
+    |> validate_required([:station_id, :user_id, :track_id])
+  end
+
+  def for_station(id) do
+    from(h in StationTrackHistory,
+      where: h.station_id == ^id,
+      where: not is_nil(h.finished_at),
+      join: t in Track,
+      on: t.id == h.track_id,
+      join: u in User,
+      on: u.id == h.user_id,
+      order_by: [desc: h.started_at],
+      select: %{
+        dj: u,
+        artwork_url: t.artwork_url,
+        duration: t.duration,
+        started_at: h.started_at,
+        finished_at: h.finished_at,
+        url: t.url,
+        poster: t.poster,
+        name: t.name,
+        provider: t.provider
+      },
+      limit: 10
+    )
+  end
+
+  def older_than(queryable, last_timestamp) do
+    from(q in queryable,
+      where: q.finished_at < ^last_timestamp
+    )
+  end
+end

--- a/lib/ripple_web/controllers/station_history_controller.ex
+++ b/lib/ripple_web/controllers/station_history_controller.ex
@@ -1,0 +1,19 @@
+defmodule RippleWeb.StationHistoryController do
+  use RippleWeb, :controller
+
+  alias Ripple.Stations
+
+  action_fallback(RippleWeb.FallbackController)
+
+  def show(conn, %{"slug" => slug, "last_timestamp" => last_timestamp}) do
+    with {:ok, history} <- Stations.get_history(slug, last_timestamp) do
+      render(conn, "show.json", history: history)
+    end
+  end
+
+  def show(conn, %{"slug" => slug}) do
+    with {:ok, history} <- Stations.get_history(slug) do
+      render(conn, "show.json", history: history)
+    end
+  end
+end

--- a/lib/ripple_web/router.ex
+++ b/lib/ripple_web/router.ex
@@ -18,6 +18,8 @@ defmodule RippleWeb.Router do
       param: "slug"
     )
 
+    get("/stations/:slug/history", StationHistoryController, :show, param: "slug")
+
     post("/playlists/:slug", PlaylistController, :add, param: "slug")
     delete("/playlists/:slug", PlaylistController, :remove, param: "slug")
     resources("/playlists", PlaylistController, only: [:create, :show], param: "slug")

--- a/lib/ripple_web/views/station_history_view.ex
+++ b/lib/ripple_web/views/station_history_view.ex
@@ -1,0 +1,8 @@
+defmodule RippleWeb.StationHistoryView do
+  use RippleWeb, :view
+  alias RippleWeb.TrackView
+
+  def render("show.json", %{history: history}) do
+    render_many(history, TrackView, "track_history.json")
+  end
+end

--- a/lib/ripple_web/views/station_view.ex
+++ b/lib/ripple_web/views/station_view.ex
@@ -19,7 +19,6 @@ defmodule RippleWeb.StationView do
         render_one(Map.get(station, :current_track, nil), TrackView, "current_track.json"),
       queue: Enum.count(Map.get(station, :queue, [])),
       tags: station.tags,
-      users: render_many(Map.get(station, :users, []), UserView, "user.json"),
       guests: Map.get(station, :guests, 0),
       total_listeners: Enum.count(station.users) + Map.get(station, :guests, 0),
       slug: station.slug

--- a/lib/ripple_web/views/track_view.ex
+++ b/lib/ripple_web/views/track_view.ex
@@ -38,4 +38,17 @@ defmodule RippleWeb.TrackView do
       }
     }
   end
+
+  def render("track_history.json", %{track: track}) do
+    %{
+      artwork_url: track.artwork_url,
+      duration: track.duration,
+      dj: render_one(track.dj, UserView, "user.json"),
+      started_at: track.started_at,
+      finished_at: track.finished_at,
+      name: track.name,
+      provider: track.provider,
+      url: track.url
+    }
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ripple.Mixfile do
   def project do
     [
       app: :ripple,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
@@ -20,7 +20,7 @@ defmodule Ripple.Mixfile do
   def application do
     [
       mod: {Ripple.Application, []},
-      extra_applications: [:logger, :runtime_tools, :httpoison]
+      extra_applications: [:logger, :runtime_tools, :httpoison, :canada]
     ]
   end
 

--- a/priv/repo/migrations/20181219213053_create_station_track_history_table.exs
+++ b/priv/repo/migrations/20181219213053_create_station_track_history_table.exs
@@ -1,0 +1,13 @@
+defmodule Ripple.Repo.Migrations.CreateStationTrackHistoryTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:station_track_history, primary_key: false) do
+      add(:station_id, references(:stations, on_delete: :nothing, type: :binary_id), null: false)
+      add(:user_id, references(:users, on_delete: :nothing, type: :binary_id), null: false)
+      add(:track_id, references(:tracks, on_delete: :nothing), null: false)
+      timestamps(inserted_at: :started_at, updated_at: false)
+      add(:finished_at, :naive_datetime, default: nil)
+    end
+  end
+end

--- a/test/ripple/stations/station_history_test.exs
+++ b/test/ripple/stations/station_history_test.exs
@@ -93,15 +93,18 @@ defmodule Ripple.StationHistoryTest do
 
     test "get_history/2 returns history for station older than provided timestamp", context do
       Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+      Process.sleep(1000)
       Stations.mark_track_as_finished(context.station.id)
-      Process.sleep(500)
+      Process.sleep(1000)
       Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+      Process.sleep(1000)
       Stations.mark_track_as_finished(context.station.id)
 
       {:ok, history} = Stations.get_history(context.station.slug)
       first = List.first(history)
       {:ok, older} = Stations.get_history(context.station.slug, first.finished_at)
       assert Enum.count(older) == 1
+      assert List.first(older).started_at < first.started_at
       assert List.first(older).finished_at < first.finished_at
     end
 

--- a/test/ripple/stations/station_history_test.exs
+++ b/test/ripple/stations/station_history_test.exs
@@ -1,0 +1,112 @@
+defmodule Ripple.StationHistoryTest do
+  use Ripple.DataCase
+
+  alias Ripple.Stations
+  alias Ripple.Stations.StationTrackHistory
+
+  describe "Station History" do
+    setup do
+      {:ok, user} = Ripple.Users.upsert_user(%{username: "tester"})
+
+      {:ok, station} =
+        Ripple.Stations.create_station(%{
+          creator_id: user.id,
+          name: "test-station",
+          tags: [],
+          visibility: "public"
+        })
+
+      track = Ripple.Tracks.get_or_create_track("https://www.youtube.com/watch?v=4Rc-NGWEHdU")
+
+      %{user: user, station: station, track: track}
+    end
+
+    test "add_track_to_history/3 works for valid arguments", context do
+      {:ok, %StationTrackHistory{}} =
+        Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+    end
+
+    test "add_track_to_history/3 fails for invalid station_id", context do
+      assert_raise Ecto.ChangeError, fn ->
+        Stations.add_track_to_history("invalid", context.user.id, context.track.id)
+      end
+    end
+
+    test "add_track_to_history/3 fails for invalid user_id", context do
+      assert_raise Ecto.ChangeError, fn ->
+        Stations.add_track_to_history(context.station.id, "invalid", context.track.id)
+      end
+    end
+
+    test "add_track_to_history/3 fails for invalid track_id", context do
+      assert {:error, %Ecto.Changeset{}} =
+               Stations.add_track_to_history(context.station.id, context.user.id, "invalid")
+    end
+
+    test "mark_track_as_finished/1 successfully sets a track to finished", context do
+      Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+
+      {:ok, empty} = Stations.get_history(context.station.slug)
+      assert Enum.count(empty) == 0
+
+      Stations.mark_track_as_finished(context.station.id)
+      {:ok, history} = Stations.get_history(context.station.slug)
+      assert Enum.count(history) == 1
+    end
+
+    test "mark_track_as_finished/1 does nothing when station does not have a current track",
+         context do
+      assert {0, nil} = Stations.mark_track_as_finished(context.station.id)
+    end
+
+    test "mark_track_as_finished/1 fails for invalid station id" do
+      assert_raise Ecto.Query.CastError, fn ->
+        Stations.mark_track_as_finished("invalid")
+      end
+    end
+
+    test "get_history/1 returns empty for station with no history", context do
+      assert {:ok, []} = Stations.get_history(context.station.slug)
+    end
+
+    test "get_history/1 returns history for station", context do
+      Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+
+      {:ok, empty} = Stations.get_history(context.station.slug)
+      assert Enum.count(empty) == 0
+
+      Stations.mark_track_as_finished(context.station.id)
+
+      {:ok, history} = Stations.get_history(context.station.slug)
+      first = List.first(history)
+      assert first.dj.id == context.user.id
+      assert first.url == context.track.url
+    end
+
+    test "get_history/1 returns error when station id is invalid" do
+      assert {:error, :not_found} == Stations.get_history("invalid")
+    end
+
+    test "get_history/2 returns empty for station with no history", context do
+      assert {:ok, []} = Stations.get_history(context.station.slug, DateTime.utc_now())
+    end
+
+    test "get_history/2 returns history for station older than provided timestamp", context do
+      Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+      Stations.mark_track_as_finished(context.station.id)
+      Process.sleep(500)
+      Stations.add_track_to_history(context.station.id, context.user.id, context.track.id)
+      Stations.mark_track_as_finished(context.station.id)
+
+      {:ok, history} = Stations.get_history(context.station.slug)
+      first = List.first(history)
+      {:ok, older} = Stations.get_history(context.station.slug, first.finished_at)
+      assert Enum.count(older) == 1
+      assert List.first(older).finished_at < first.finished_at
+    end
+
+    test "get_history/2 returns error when station id is invalid" do
+      assert {:error, :not_found} == Stations.get_history("invalid")
+    end
+  end
+end

--- a/test/ripple_web/controllers/station_history_controller_test.exs
+++ b/test/ripple_web/controllers/station_history_controller_test.exs
@@ -1,0 +1,56 @@
+defmodule RippleWeb.StationHistoryControllerTest do
+  use RippleWeb.ConnCase
+
+  alias Ripple.Stations
+
+  @create_attrs %{name: "some name", visibility: "public", tags: []}
+  @track_url "https://www.youtube.com/watch?v=4Rc-NGWEHdU"
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  def fixture do
+    {:ok, user} = Ripple.Users.create_user(%{username: "tester"})
+    {:ok, station} = Stations.create_station(@create_attrs |> Map.put(:creator_id, user.id))
+    track = Ripple.Tracks.get_or_create_track(@track_url)
+    %{station: station, user: user, track: track}
+  end
+
+  describe "show" do
+    test "404 when station does not exist", %{conn: conn} do
+      conn = get(conn, station_history_path(conn, :show, "invalid"))
+      assert %{"errors" => %{"detail" => "Page not found"}} == json_response(conn, 404)
+    end
+
+    test "renders empty history for station with no history", %{conn: conn} do
+      %{station: station} = fixture()
+      conn = get(conn, station_history_path(conn, :show, station.slug))
+      assert [] == json_response(conn, 200)
+    end
+
+    test "renders history for station with history", %{conn: conn} do
+      %{station: station, user: user, track: track} = fixture()
+      Stations.add_track_to_history(station.id, user.id, track.id)
+      Stations.mark_track_as_finished(station.id)
+      conn = get(conn, station_history_path(conn, :show, station.slug))
+      history = json_response(conn, 200)
+      assert Enum.count(history) == 1
+    end
+
+    test "last_timestamp param allows pagination", %{conn: conn} do
+      %{station: station, user: user, track: track} = fixture()
+      Stations.add_track_to_history(station.id, user.id, track.id)
+      Stations.mark_track_as_finished(station.id)
+
+      {:ok, h} = Stations.get_history(station.slug)
+
+      conn =
+        get(conn, station_history_path(conn, :show, station.slug), %{
+          last_timestamp: List.first(h).finished_at
+        })
+
+      assert [] == json_response(conn, 200)
+    end
+  end
+end

--- a/test/support/cluster_helper.ex
+++ b/test/support/cluster_helper.ex
@@ -27,6 +27,7 @@ defmodule Ripple.ClusterHelper do
   end
 
   def cleanup() do
+    Ripple.Repo.delete_all(Ripple.Stations.StationTrackHistory)
     Ripple.Repo.delete_all(Ripple.Stations.Station)
     Ripple.Repo.delete_all(Ripple.Users.User)
     Ripple.Repo.delete_all(Ripple.Tracks.Track)


### PR DESCRIPTION
## [0.1.5] - 2018-12-21

### Added

- Stations now save track history and current track in postgres
- `/stations/:slug/history` endpoint for fetching station track history