### PR TITLE
Live station follower count is now updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2019-03-02
+
+### Fixed
+
+- Endpoints for user created stations now return valid information when a station is live
+- Follower count on live stations is now updated when a station is followed/unfollowed
+
 ## [0.2.0] - 2019-03-01
 
 ### Fixed

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,8 @@ config :event_bus,
     :station_user_left,
     :station_track_started,
     :station_track_finished,
-    :station_queue_track_added
+    :station_queue_track_added,
+    :station_follower_count_updated
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/lib/ripple/stations/station_server.ex
+++ b/lib/ripple/stations/station_server.ex
@@ -41,6 +41,10 @@ defmodule Ripple.Stations.StationServer do
     GenServer.cast(via_tuple(slug), {:add_track, track_url, user})
   end
 
+  def increment_follower_count(slug, amount) do
+    GenServer.call(via_tuple(slug), {:increment_follower_count, amount})
+  end
+
   def get(slug), do: GenServer.call(via_tuple(slug), :get)
 
   def init({%Station{} = station, nil}) do
@@ -104,6 +108,16 @@ defmodule Ripple.Stations.StationServer do
     new_state = %LiveStation{state | users: filtered_users ++ [user]}
     emit_event(:station_user_joined, %{station: new_state, target: user})
     {:reply, :ok, new_state}
+  end
+
+  def handle_call(
+        {:increment_follower_count, amount},
+        _,
+        %LiveStation{followers: followers} = state
+      ) do
+    new_state = %LiveStation{state | followers: followers + amount}
+    emit_event(:station_follower_count_updated, %{station: new_state, target: new_state})
+    {:reply, new_state, new_state}
   end
 
   def handle_cast(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ripple.Mixfile do
   def project do
     [
       app: :ripple,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
### Fixed

- Endpoints for user created stations now return valid information when a station is live
- Follower count on live stations is now updated when a station is followed/unfollowed